### PR TITLE
Fix sorting immutable recipe lists

### DIFF
--- a/src/main/java/safro/zenith/ench/compat/EnchREIPlugin.java
+++ b/src/main/java/safro/zenith/ench/compat/EnchREIPlugin.java
@@ -52,8 +52,9 @@ public class EnchREIPlugin implements REIClientPlugin {
 
         registry.registerFiller(EnchantingRecipe.class, EnchantingDisplay::new);
         List<EnchantingRecipe> recipes = Minecraft.getInstance().level.getRecipeManager().getAllRecipesFor(EnchModule.INFUSION_RECIPE);
-        recipes.sort((r1, r2) -> Float.compare(r1.getRequirements().eterna, r2.getRequirements().eterna));
-        recipes.forEach(registry::add);
+        recipes.stream()
+                .sorted((r1, r2) -> Float.compare(r1.getRequirements().eterna, r2.getRequirements().eterna))
+                .forEach(registry::add);
 
         REIUtil.addInfo(registry, EnchModule.LIBRARY, "info.zenith.library");
         REIUtil.addInfo(registry, Blocks.ENCHANTING_TABLE, "info.zenith.enchanting");

--- a/src/main/java/safro/zenith/spawn/modifiers/SpawnerModifier.java
+++ b/src/main/java/safro/zenith/spawn/modifiers/SpawnerModifier.java
@@ -129,10 +129,11 @@ public class SpawnerModifier implements Recipe<Container> {
 	@Nullable
 	public static SpawnerModifier findMatch(ApothSpawnerTile tile, ItemStack mainhand, ItemStack offhand) {
 		List<SpawnerModifier> recipes = tile.getLevel().getRecipeManager().getAllRecipesFor(SpawnerModule.MODIFIER);
-		recipes.sort((r1, r2) -> r1.offHand == Ingredient.EMPTY ? r2.offHand == Ingredient.EMPTY ? 0 : 1 : -1);
-		for (SpawnerModifier r : recipes)
-			if (r.matches(tile, mainhand, offhand)) return r;
-		return null;
+		return recipes.stream()
+				.sorted((r1, r2) -> r1.offHand == Ingredient.EMPTY ? r2.offHand == Ingredient.EMPTY ? 0 : 1 : -1)
+				.filter(r -> r.matches(tile, mainhand, offhand))
+				.findFirst()
+				.orElse(null);
 	}
 
 	public static class Serializer implements RecipeSerializer<SpawnerModifier> {


### PR DESCRIPTION
The sorting was being done in-place on the list returned from the recipe manager.
The list being immutable resulted in a crash.

Went with sorting a stream instead, let me know if any changes are required.