### PR TITLE
Fix always max enchantment

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">

--- a/src/main/java/dev/shadowsoffire/apotheosis/ench/EnchantmentInfo.java
+++ b/src/main/java/dev/shadowsoffire/apotheosis/ench/EnchantmentInfo.java
@@ -66,13 +66,19 @@ public class EnchantmentInfo {
     }
 
     public static EnchantmentInfo load(Enchantment ench, Configuration cfg) {
+        float maxEnchantmentLevel = EnchModule.getDefaultMax(ench);
+        float absoluteMaxPower = EnchantingStatRegistry.getAbsoluteMaxEterna() * 2f;
+        int powerScalar = Mth.floor(absoluteMaxPower / maxEnchantmentLevel);
+        String defaultMaxF = String.format("%d * x", powerScalar);
+        String defaultMinF = "1";
+        
         String category = BuiltInRegistries.ENCHANTMENT.getKey(ench).toString();
         int max = cfg.getInt("Max Level", category, EnchModule.getDefaultMax(ench), 1, 127, "The max level of this enchantment - originally " + ench.getMaxLevel() + ".");
         int maxLoot = cfg.getInt("Max Loot Level", category, ench.getMaxLevel(), 1, 127, "The max level of this enchantment available from loot sources.");
-        String maxF = cfg.getString("Max Power Function", category, "", "A function to determine the max enchanting power.  The variable \"x\" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples");
-        String minF = cfg.getString("Min Power Function", category, "", "A function to determine the min enchanting power.");
-        PowerFunc maxPower = maxF.isEmpty() ? defaultMax(ench) : new ExpressionPowerFunc(maxF);
-        PowerFunc minPower = minF.isEmpty() ? defaultMin(ench) : new ExpressionPowerFunc(minF);
+        String maxF = cfg.getString("Max Power Function", category, defaultMaxF, "A function to determine the max enchanting power.  The variable \"x\" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples");
+        String minF = cfg.getString("Min Power Function", category, defaultMinF, "A function to determine the min enchanting power.");
+        PowerFunc maxPower = maxF.isEmpty() ? new ExpressionPowerFunc(defaultMaxF) : new ExpressionPowerFunc(maxF);
+        PowerFunc minPower = minF.isEmpty() ? new ExpressionPowerFunc(defaultMinF) : new ExpressionPowerFunc(minF);
         boolean treasure = cfg.getBoolean("Treasure", category, ench.isTreasureOnly(), "If this enchantment is only available by loot sources.");
         boolean discoverable = cfg.getBoolean("Discoverable", category, ench.isDiscoverable(), "If this enchantment is obtainable via enchanting and enchanted loot items.");
         boolean lootable = cfg.getBoolean("Lootable", category, ench.isDiscoverable(), "If enchanted books of this enchantment are available via loot sources.");

--- a/src/main/java/dev/shadowsoffire/apotheosis/ench/table/RealEnchantmentHelper.java
+++ b/src/main/java/dev/shadowsoffire/apotheosis/ench/table/RealEnchantmentHelper.java
@@ -140,7 +140,7 @@ public class RealEnchantmentHelper {
 
             if (special || enchantment.canEnchant(stack) || item.forciblyAllowsTableEnchantment(stack, enchantment) ) {
                 for (int level = info.getMaxLevel(); level > enchantment.getMinLevel() - 1; --level) {
-                    if (power >= info.getMinPower(level) && power >= info.getMaxPower(level)) {
+                    if (power >= info.getMinPower(level) && (power >= info.getMaxPower(level) || level == enchantment.getMinLevel())) {
                         list.add(new EnchantmentInstance(enchantment, level));
                         break;
                     }

--- a/src/main/java/dev/shadowsoffire/apotheosis/ench/table/RealEnchantmentHelper.java
+++ b/src/main/java/dev/shadowsoffire/apotheosis/ench/table/RealEnchantmentHelper.java
@@ -140,7 +140,7 @@ public class RealEnchantmentHelper {
 
             if (special || enchantment.canEnchant(stack) || item.forciblyAllowsTableEnchantment(stack, enchantment) ) {
                 for (int level = info.getMaxLevel(); level > enchantment.getMinLevel() - 1; --level) {
-                    if (power >= info.getMinPower(level) && power <= info.getMaxPower(level)) {
+                    if (power >= info.getMinPower(level) && power >= info.getMaxPower(level)) {
                         list.add(new EnchantmentInstance(enchantment, level));
                         break;
                     }


### PR DESCRIPTION
Adjusted default configuration for enchantment min power level and max power level to evenly distribute the level between power power level 1 and 100. Also provides a clear example of what the expressions can look like for users reading/configuring it.

Fixed two bugs with the enchanting module.
1. Max level enchants were commonly available through minimum power level tables (Eff IX with level 1)
2. If the resultant of the max power function was greater than the current tables power level for the minimum level enchantment AND the power level was still greater than the minimum power level required, you would be unable to enchant with the low level enchantment.
E.G., if efficiency 1 had a max power calculated to be 5, the minimum power is 1, and the enchantment table has a power of 3. Than you could not enchant efficiency 1 even though you meet the minimum power. This has been fixed in the situation that it is the minimum enchantment level.