### PR TITLE
Fix Issue #130 - Missing Enchant No Filter

### DIFF
--- a/src/main/java/dev/shadowsoffire/apotheosis/ench/library/EnchLibraryScreen.java
+++ b/src/main/java/dev/shadowsoffire/apotheosis/ench/library/EnchLibraryScreen.java
@@ -237,7 +237,7 @@ public class EnchLibraryScreen extends AbstractContainerScreen<EnchLibraryContai
     private boolean isAllowedByItem(Entry<Enchantment> e) {
         ItemStack stack = this.menu.ioInv.getItem(2);
 
-        if (FabricLoader.getInstance().isModLoaded("spell_power")){
+        if (!stack.isEmpty() && FabricLoader.getInstance().isModLoaded("spell_power")){
             if (EnchantmentRestriction.isPermitted(e.getKey(), stack)) return true;
             if (EnchantmentRestriction.isProhibited(e.getKey(), stack)) return false;
         }


### PR DESCRIPTION
Simple fix to ensure spell_power enchantments will show in the UI when no filter is applied.
See https://github.com/TheWinABagel/Zenith/issues/130.