### PR TITLE
Initial EasyAnvils Compat Fix

### DIFF
--- a/src/main/java/dev/shadowsoffire/apotheosis/mixin/ench/anvil/AnvilBlockMixin.java
+++ b/src/main/java/dev/shadowsoffire/apotheosis/mixin/ench/anvil/AnvilBlockMixin.java
@@ -61,7 +61,9 @@ public abstract class AnvilBlockMixin extends FallingBlock implements INBTSensit
     @Nullable
     @Override
     public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
-        return new AnvilTile(pos, state);
+        if (Apotheosis.enableEnch){
+            return new AnvilTile(pos, state);
+        } else return null;
     }
 
     @Environment(EnvType.CLIENT)


### PR DESCRIPTION
## Description
This PR adds a missing conditional.
The addition of said conditional enabels basic EasyAnvils compat. 
When the enchantment module is disabled, `AnvilTile` shouldn't be over written. 
This makes the basic function of EasyAnvils work with Zenith, only caviat at the moment is that the rendering of the items staying in the anvil is not working yet. 
Functionality is restored though.

## Potentially Fixes
https://github.com/TheWinABagel/Zenith/issues/233

## Details

Tested with the following:
- Zenith `1.2.4`
- Zenith Attributes `0.2.8`
- fakerlib `0.1.4`
- EasyAnvils `8.0.2`
- fabric_version `0.92.2+1.20.1`

![grafik](https://github.com/user-attachments/assets/15fef56a-df31-4668-84d4-df3eeeb0441d)
